### PR TITLE
Fix unused parameters warnings in release mode

### DIFF
--- a/server/src/debug.h
+++ b/server/src/debug.h
@@ -156,9 +156,9 @@ public:
   static int set_verbosity(char const *str);
 
 #else
-  static int get_verbosity(unsigned c, char const **str)
+  static int get_verbosity(unsigned, char const **)
   { return -L4_EINVAL; }
-  static int get_verbosity(char const *c, char const **str)
+  static int get_verbosity(char const *, char const **)
   { return -L4_EINVAL; }
   static void set_verbosity(unsigned, unsigned) {}
   static void set_verbosity(unsigned) {}


### PR DESCRIPTION
In release mode some parameters are unused. They will generate a warning
if specified in the signature. Remove the parameter names to quelch the
warnings.

Change-Id: I6dde13762750ab2d3a0aa3dc0de783531fee19bc