### PR TITLE
Remove unused method

### DIFF
--- a/server/src/device.h
+++ b/server/src/device.h
@@ -166,25 +166,7 @@ struct Device_lookup
     };
     return (res < sizeof(err)/sizeof(err[0])) ? err[res] : "unknown error";
   }
-  /**
-   * Get the interrupt controller for a given node.
-   *
-   * \param node   The device tree node an interrupt parent is looked for.
-   * \param fatal  Abort if true and no virtual device for the interrupt parent
-   *               could be found.
-   *
-   * \return Either a pointer to the virtual device of the interrupt parent or
-   *         nullptr in case of an error
-   *
-   * This method tries to fetch and return the interrupt parent of the node. If
-   * the device doesn't exist yet and is a virtual device it tries to create it.
-   * It walks the interrupt tree up and creates the missing devices starting
-   * with the top most missing device. If creation of any device fails it
-   * emits a diagnostic message and aborts if fatal is true. Otherwise it
-   * returns a nullptr.
-   */
-  virtual cxx::Ref_ptr<Gic::Ic>get_or_create_ic_dev(Vdev::Dt_node const &node,
-                                                    bool fatal) = 0;
+
   /**
    * Get the interrupt controller for a given node.
    *

--- a/server/src/vm.cc
+++ b/server/src/vm.cc
@@ -49,23 +49,6 @@ Vm::get_or_create_ic(Vdev::Dt_node const &node, cxx::Ref_ptr<Gic::Ic> *ic_ptr)
   return Ic_ok;
 }
 
-cxx::Ref_ptr<Gic::Ic>
-Vm::get_or_create_ic_dev(Vdev::Dt_node const &node, bool fatal)
-{
-  cxx::Ref_ptr<Gic::Ic> ic;
-  Ic_error res = get_or_create_ic(node, &ic);
-  if (res == Ic_ok)
-    return ic;
-
-  Dbg(Dbg::Dev, Dbg::Info).printf("%s: Failed to get interrupt parent: %s\n",
-                                  node.get_name(), ic_err_str(res));
-
-  if (fatal)
-    L4Re::chksys(-L4_ENODEV, "Unable to locate interrupt parent");
-
-  return nullptr;
-}
-
 cxx::Ref_ptr<Gic::Msix_controller>
 Vm::get_or_create_mc_dev(Vdev::Dt_node const &node)
 {

--- a/server/src/vm.h
+++ b/server/src/vm.h
@@ -45,12 +45,6 @@ public:
   { return _cpus; }
 
   /**
-   * \see Device_lookup::get_or_create_ic_dev(Vdev::Dt_node const &node,
-   *                                          bool fatal)
-   */
-  cxx::Ref_ptr<Gic::Ic> get_or_create_ic_dev(Vdev::Dt_node const &node,
-                                             bool fatal) override;
-  /**
    * \see Device_lookup::get_or_create_ic(Vdev::Dt_node const &node,
    *                                      cxx::Ref_ptr<Gic::Ic> *ic_ptr)
    */


### PR DESCRIPTION
It's usage was removed in Ic7613c4f8503bf38a3117067926108b25f880ead.
However, the implementation itself stayed in uvmm until now.

Change-Id: I72fc669ffa13277b74b41b4491328222ae1054a1